### PR TITLE
Feature: `width` argument to calculate scale from number of available columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Options:
           [default: 4]
 
   -w, --width <WIDTH>
-          In case you know how many columns are needed, this paramter will calcualte the scale factor for you.
+          Width expressed as text-columns, this parameter will calculate the scale factor for you.
           Overrides `scale` parameter even when specified.
 
           [default: disabled]

--- a/README.md
+++ b/README.md
@@ -106,10 +106,7 @@ Options:
           [default: 4]
 
   -w, --width <WIDTH>
-          Width expressed as text-columns, this parameter will calculate the scale factor for you.
-          Overrides `scale` parameter even when specified.
-
-          [default: disabled]
+          Enstablish how much wide is the output images, in columns. Overrides `scale`
 
   -b, --background <BACKGROUND>
           The background color to use

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Options:
           
           [default: 4]
 
+  -w, --width <WIDTH>
+          In case you know how many columns are needed, this paramter will calcualte the scale factor for you.
+          Overrides `scale` parameter even when specified.
+
+          [default: disabled]
+
   -b, --background <BACKGROUND>
           The background color to use
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,7 +19,7 @@ pub mod args {
         /// The output scale (1 is the original size)
         #[arg(short, long, default_value = "4")]
         pub scale: u32,
-        // Enstablish how much wide is the output images, in columns. Overrides `scale`
+        /// Enstablish how much wide is the output images, in columns. Overrides `scale`
         #[arg(short, long, default_value= None )]
         pub width: Option<u32>,
         /// The background color to use

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,6 +19,9 @@ pub mod args {
         /// The output scale (1 is the original size)
         #[arg(short, long, default_value = "4")]
         pub scale: u32,
+        // Enstablish how much wide is the output images, in columns. Overrides `scale`
+        #[arg(short, long, default_value= None )]
+        pub width: Option<u32>,
         /// The background color to use
         #[arg(short, long, default_value = None)]
         pub background: Option<String>,

--- a/src/ascii_processor.rs
+++ b/src/ascii_processor.rs
@@ -66,6 +66,7 @@ fn get_character(
 /// Determine how much scale to use in presence of `width` parameters,
 /// otherwise returns regular `scale` parameter per default behaviour
 ///
+#[inline]
 fn calculate_scale(args: &Arguments, dimensions: (u32, u32)) -> u32 {
     args.width.map_or_else(|| args.scale, |v| dimensions.0 / v)
 }

--- a/src/ascii_processor.rs
+++ b/src/ascii_processor.rs
@@ -11,10 +11,11 @@ pub fn generate_ascii<W: Write>(
 ) -> io::Result<()> {
     let characters = args.characters.chars().collect::<Vec<char>>();
     let (width, height) = image.dimensions();
+    let actual_scale = calculate_scale(args, (width, height));
 
     for y in 0..height {
         for x in 0..width {
-            if y % (args.scale * 2) == 0 && x % args.scale == 0 {
+            if y % (actual_scale * 2) == 0 && x % actual_scale == 0 {
                 let element = get_character(
                     image.get_pixel(x, y),
                     &characters,
@@ -26,7 +27,7 @@ pub fn generate_ascii<W: Write>(
             }
         }
         // Add a new line at the end of each row
-        if y % (args.scale * 2) == 0 {
+        if y % (actual_scale * 2) == 0 {
             buffer.write_all("\n".as_bytes())?;
         }
     }
@@ -58,5 +59,59 @@ fn get_character(
     match background {
         Some(bg) => ch.on_color(bg.to_string()),
         None => ch,
+    }
+}
+
+///
+/// Determine which scale to use in presence of `width` parameters,
+/// otherwise uses regular `scale` parameter as default
+///
+fn calculate_scale(args: &Arguments, dimensions: (u32, u32)) -> u32 {
+    args.width.map_or_else(|| args.scale, |v| dimensions.0 / v)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::args::{
+        args::Arguments,
+        enums::{Mode, OutputMethod},
+    };
+
+    use super::calculate_scale;
+
+    const DIMENSIONS: (u32, u32) = (100, 100);
+
+    #[test]
+    fn test_scale() {
+        let args = Arguments {
+            mode: Mode::NormalAscii,
+            output_method: OutputMethod::Stdout,
+            image: "".into(),
+            characters: "".into(),
+            scale: 4,
+            width: Some(10),
+            background: None,
+            output: "".into(),
+        };
+
+        let scale = calculate_scale(&args, DIMENSIONS);
+        assert_eq!(scale, 10);
+    }
+
+    #[test]
+    fn test_default_scale() {
+        let args = Arguments {
+            mode: Mode::NormalAscii,
+            output_method: OutputMethod::Stdout,
+            image: "".into(),
+            characters: "".into(),
+            scale: 4,
+            width: None,
+            background: None,
+            output: "".into(),
+        };
+
+        let scale = calculate_scale(&args, DIMENSIONS);
+        assert_eq!(scale, 4);
     }
 }

--- a/src/ascii_processor.rs
+++ b/src/ascii_processor.rs
@@ -63,8 +63,8 @@ fn get_character(
 }
 
 ///
-/// Determine which scale to use in presence of `width` parameters,
-/// otherwise uses regular `scale` parameter as default
+/// Determine how much scale to use in presence of `width` parameters,
+/// otherwise returns regular `scale` parameter per default behaviour
 ///
 fn calculate_scale(args: &Arguments, dimensions: (u32, u32)) -> u32 {
     args.width.map_or_else(|| args.scale, |v| dimensions.0 / v)


### PR DESCRIPTION
Hello, its me again :smiley:  

I'm using your converter and found myself in this situation: I wanted to `aartyze` a bunch of pics from different size, all to an ascii file the same width.
This feature come out naturally and gave the occasion of testing a small part of the code.

Do you think this could help you? 